### PR TITLE
nRF Connect SDK v2.3系対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # さくらのモノプラットフォーム Client library for nRFConnect
 
+nRF9160＆nRF Connect SDK v2.3系に対応したクライアントライブラリです。
+
 See also description to [Wiki](https://github.com/sakura-internet/sipf-lib_nrfconnect/wiki) page.(in Japanese)
 
 詳細は[Wiki](https://github.com/sakura-internet/sipf-lib_nrfconnect/wiki)を参照してください。

--- a/include/sipf/sipf_client_http.h
+++ b/include/sipf/sipf_client_http.h
@@ -6,7 +6,7 @@
 #ifndef SIPF_CLIENT_HTTP_H
 #define SIPF_CLIENT_HTTP_H
 
-#include <net/http_client.h>
+#include <zephyr/net/http/client.h>
 #include "sipf/sipf_object.h"
 
 #define HTTP_PORT 80

--- a/include/sipf/sipf_file.h
+++ b/include/sipf/sipf_file.h
@@ -8,9 +8,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <net/socket.h>
+#include <zephyr/net/socket.h>
 #include <net/download_client.h>
-#include <net/http_client.h>
+#include <zephyr/net/http/client.h>
 
 int SipfFileRequestDownloadURL(const char *file_id, char *url, int sz_url);
 int SipfFileRequestUploadURL(const char *file_id, char *url, int sz_url);

--- a/include/sipf/sipf_object.h
+++ b/include/sipf/sipf_object.h
@@ -60,7 +60,7 @@ typedef struct
 typedef struct
 {
     uint8_t obj_qty;
-    SipfObjectObject obj;
+    SipfObjectObject *objs;
 } SipfObjectUp;
 
 typedef struct

--- a/src/sipf_auth.c
+++ b/src/sipf_auth.c
@@ -5,7 +5,7 @@
  */
 #include <logging/log.h>
 
-LOG_MODULE_DECLARE(sipf);
+LOG_MODULE_REGISTER(sipf);
 
 #include "sipf/sipf_auth.h"
 #include "sipf/sipf_client_http.h"
@@ -66,7 +66,7 @@ int SipfAuthRequest(char *user_name, uint8_t sz_user_name, char *password, uint8
     LOG_INF("content-length: %d", http_res.content_length);
     // FIXME: CONFIG_SIPF_LOG_LEVEL をつかっていい感じに抑制する
     for (int i = 0; i < http_res.content_length; i++) {
-        LOG_DBG("0x%02x ", http_res.body_start[i]);
+        LOG_DBG("0x%02x ", http_res.body_frag_start[i]);
     }
     // FIXME: ここまで
 
@@ -77,13 +77,13 @@ int SipfAuthRequest(char *user_name, uint8_t sz_user_name, char *password, uint8
 
     // レスポンスのフォーマットは USERNAME\nPASSWORD\n
     // FIXME: 例外処理もしっかりやる
-    char *u = (char *)&http_res.body_start[0];
+    char *u = (char *)&http_res.body_frag_start[0];
     char *p = NULL;
     for (int i = 0; i < http_res.content_length; i++) {
-        if (http_res.body_start[i] == '\n') {
-            http_res.body_start[i] = 0;
+        if (http_res.body_frag_start[i] == '\n') {
+            http_res.body_frag_start[i] = 0;
             if (p == NULL) {
-                p = (char *)&(http_res.body_start[i + 1]);
+                p = (char *)&(http_res.body_frag_start[i + 1]);
             }
         }
     }

--- a/src/sipf_auth.c
+++ b/src/sipf_auth.c
@@ -5,7 +5,7 @@
  */
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(sipf);
+LOG_MODULE_DECLARE(sipf);
 
 #include "sipf/sipf_auth.h"
 #include "sipf/sipf_client_http.h"

--- a/src/sipf_auth.c
+++ b/src/sipf_auth.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(sipf);
 

--- a/src/sipf_client_http.c
+++ b/src/sipf_client_http.c
@@ -6,11 +6,11 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <net/net_ip.h>
-#include <net/socket.h>
-#include <net/tls_credentials.h>
-#include <sys/base64.h>
-#include <logging/log.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/tls_credentials.h>
+#include <zephyr/sys/base64.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(sipf);
 

--- a/src/sipf_file.c
+++ b/src/sipf_file.c
@@ -99,7 +99,7 @@ static int sipfFileRequestURL(enum req_url_type req_type, const char *file_id, c
         return -1;
     }
 
-    strncpy(url, http_res.body_start, http_res.content_length);
+    strncpy(url, http_res.body_frag_start, http_res.content_length);
     LOG_HEXDUMP_INF(url, http_res.content_length, "url:");
     return http_res.content_length;
 }
@@ -397,7 +397,7 @@ int SipfFileDownload(const char *file_id, uint8_t *buff, size_t sz_download, sip
 
     // Download Clientの設定
     struct download_client_cfg config = {
-        .sec_tag = sec_tag, .apn = NULL, .frag_size_override = sz_download, .set_tls_hostname = (sec_tag != -1),
+        .sec_tag = sec_tag, .pdn_id = 0, .frag_size_override = sz_download, .set_tls_hostname = (sec_tag != -1),
     };
 
     // Download Client初期化

--- a/src/sipf_file.c
+++ b/src/sipf_file.c
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: MIT
  */
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(sipf);
 
 #include <stdio.h>
 #include <string.h>
-#include <zephyr.h>
+//#include <zephyr/zephyr.h>
 
 #include "sipf/sipf_client_http.h"
 #include "sipf/sipf_file.h"

--- a/src/sipf_object.c
+++ b/src/sipf_object.c
@@ -216,27 +216,12 @@ int SipfObjClientObjUpRaw(uint8_t *payload_buffer, uint16_t size, SipfObjectOtid
 
 int SipfObjClientObjUp(const SipfObjectUp *simp_obj_up, SipfObjectOtid *otid)
 {
-    if (simp_obj_up->obj.value == NULL) {
+    if (simp_obj_up->objs == NULL){
         return -1;
     }
 
-    uint16_t size = 3 + simp_obj_up->obj.value_len;
-    uint8_t payload[32];
-    if (size > sizeof(payload)) {
-        LOG_ERR("obj.value is too big %d", size);
-        return -1;
-    }
-
-    // OBJ
-    //  OBJ_TYPEID
-    payload[0] = simp_obj_up->obj.obj_type;
-    //  OBJ_TAGID
-    payload[1] = simp_obj_up->obj.obj_tagid;
-    //  OBJ_LENGTH
-    payload[2] = simp_obj_up->obj.value_len;
-    //  OBJ_VALUE
-    memcpy(&payload[3], simp_obj_up->obj.value, simp_obj_up->obj.value_len);
-
+    uint8_t payload[512];
+    int size = SipfObjectCreateObjUpPayload(payload, sizeof(payload), simp_obj_up->objs, simp_obj_up->obj_qty);
     return SipfObjClientObjUpRaw(payload, size, otid);
 }
 

--- a/src/sipf_object.c
+++ b/src/sipf_object.c
@@ -177,11 +177,11 @@ int SipfObjClientObjUpRaw(uint8_t *payload_buffer, uint16_t size, SipfObjectOtid
 
     LOG_DBG("Response status %s", http_res.http_status);
     LOG_DBG("content-length: %d", http_res.content_length);
-    LOG_HEXDUMP_DBG(http_res.body_start, http_res.content_length, "response:");
+    LOG_HEXDUMP_DBG(http_res.body_frag_start, http_res.body_frag_len, "response:");
 
     // OBJID_NOTIFICATIONをパース
-    uint8_t *sipf_obj_head = &http_res.body_start[0];
-    uint8_t *sipf_obj_payload = &http_res.body_start[12];
+    uint8_t *sipf_obj_head = &http_res.body_frag_start[0];
+    uint8_t *sipf_obj_payload = &http_res.body_frag_start[12];
     if (strcmp(http_res.http_status, "OK") != 0) {
         LOG_WRN("Invalid HTTP stauts %s", http_res.http_status);
         if (strcmp(http_res.http_status, "Unauthorized") == 0) {
@@ -291,9 +291,10 @@ int SipfObjClientObjDown(SipfObjectOtid *otid, uint8_t *remains, uint8_t *objqty
 
     LOG_INF("Response status %s(%d)", http_res.http_status, http_res.http_status_code);
     LOG_INF("data_len: %d content-length: %d", http_res.data_len, http_res.content_length);
+    LOG_HEXDUMP_DBG(http_res.body_frag_start, http_res.body_frag_len, "response:");
     /* レスポンスを処理 */
-    uint8_t *sipf_obj_head = &http_res.body_start[0];
-    uint8_t *sipf_obj_payload = &http_res.body_start[12];
+    uint8_t *sipf_obj_head = &http_res.body_frag_start[0];
+    uint8_t *sipf_obj_payload = &http_res.body_frag_start[12];
     if (strcmp(http_res.http_status, "OK") != 0) {
         if (strcmp(http_res.http_status, "Unauthorized") == 0) {
             return -401;

--- a/src/sipf_object.c
+++ b/src/sipf_object.c
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <string.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(sipf);
 


### PR DESCRIPTION
v2.3系をターゲットに修正。
v2.2系でもいけるかも。

v2.2.0からzephyr OS関連のヘッダファイルのパスが変更されているのでv2.2系とはソース互換性なし。