### PR TITLE
SIPFライブラリを単独で使う場合 LOG_MODULE_REGISTER(sipf) が存在しないとリンクエラーになる問題の修正

### DIFF
--- a/src/sipf_auth.c
+++ b/src/sipf_auth.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_DECLARE(sipf);
+LOG_MODULE_REGISTER(sipf);
 
 #include "sipf/sipf_auth.h"
 #include "sipf/sipf_client_http.h"


### PR DESCRIPTION
このライブラリを単体でなんらかのアプケーションに組み込みと `undefined reference to 'log_const_sipf'` になる。

どこかに `LOG_MODULE_REGISTER(sipf);` が必要だと思うので、一箇所変更した。